### PR TITLE
policy file round up

### DIFF
--- a/{{cookiecutter.safe_number}}/policies/{{cookiecutter.term}}/policy.json
+++ b/{{cookiecutter.safe_number}}/policies/{{cookiecutter.term}}/policy.json
@@ -1,19 +1,9 @@
 {
     "course/{{ cookiecutter.term }}": {
-        "allow_anonymous": false,
-        "allow_anonymous_to_peers": true,
-        "attempts": 10,
         "diplay_name": "{{ cookiecutter.name }}",
         "display_coursenumber": "{{ cookiecutter.number }}",
         "display_organization": "MIT",
-        "end": "2130-01-30T00:00",
-        "enrollment_end": "2130-01-30T00:00",
         "giturl" : "{{ cookiecutter.giturl }}",
-        "graceperiod": "0 day 0 hours 15 minutes 0 seconds",
-        "ispublic": true,
-        "rerandomize": "once",
-        "showanswer": "attempted",
-        "start": "2030-01-30T00:00",
         "tabs": [
             {
                 "type": "courseware"
@@ -21,10 +11,6 @@
             {
                 "name": "Course Info",
                 "type": "course_info"
-            },
-            {
-                "name": "Progress",
-                "type": "progress"
             }
         ],
         "checklists": [


### PR DESCRIPTION
Only distinct policy file settings are needed when importing a new course into studio.
Also, considering removing the progress bar for new studio course. They are not tied to a student's standing residentially.